### PR TITLE
Remove repetitive resizes for gradInput

### DIFF
--- a/fbcunn_files/DataParallel.lua
+++ b/fbcunn_files/DataParallel.lua
@@ -148,7 +148,6 @@ function DataParallel:updateGradInput(_input, gradOutput)
 
     -- gradInput for each module on its appropriate gpu
     if not self.gradInput then return end -- if gradInput is nil, do nothing
-    self.gradInput:resizeAs(self.input_gpu[self.container_gpuid])
 
     self.gradInput:resizeAs(_input)
     local elementsPerSlice = self.input_gpu[1]:size(self.dimension)


### PR DESCRIPTION
gradInput should be as big as the size of global input
hence the first resize has no effect for data parallel model
