### PR TITLE
assert fails on non-square images

### DIFF
--- a/donkey.lua
+++ b/donkey.lua
@@ -67,7 +67,7 @@ local trainHook = function(self, path)
    local iH = input:size(2)
 
    -- do random crop
-   local oW = sampleSize[3];
+   local oW = sampleSize[3]
    local oH = sampleSize[2]
    local h1 = math.ceil(torch.uniform(1e-2, iH-oH))
    local w1 = math.ceil(torch.uniform(1e-2, iW-oW))
@@ -75,7 +75,7 @@ local trainHook = function(self, path)
    assert(out:size(3) == oW)
    assert(out:size(2) == oH)
    -- do hflip with probability 0.5
-   if torch.uniform() > 0.5 then out = image.hflip(out); end
+   if torch.uniform() > 0.5 then out = image.hflip(out) end
    -- mean/std
    for i=1,3 do -- channels
       if mean then out[{{i},{},{}}]:add(-mean[i]) end
@@ -126,7 +126,7 @@ local testHook = function(self, path)
    collectgarbage()
    local input = loadImage(path)
    local oH = sampleSize[2]
-   local oW = sampleSize[3];
+   local oW = sampleSize[3]
    local iW = input:size(3)
    local iH = input:size(2)
    local w1 = math.ceil((iW-oW)/2)

--- a/donkey.lua
+++ b/donkey.lua
@@ -72,8 +72,8 @@ local trainHook = function(self, path)
    local h1 = math.ceil(torch.uniform(1e-2, iH-oH))
    local w1 = math.ceil(torch.uniform(1e-2, iW-oW))
    local out = image.crop(input, w1, h1, w1 + oW, h1 + oH)
-   assert(out:size(2) == oW)
-   assert(out:size(3) == oH)
+   assert(out:size(3) == oW)
+   assert(out:size(2) == oH)
    -- do hflip with probability 0.5
    if torch.uniform() > 0.5 then out = image.hflip(out); end
    -- mean/std


### PR DESCRIPTION
Fixed an assertion failure when images are non-square. Additionally took the opportunity to remove a few stray ';'.
