### PR TITLE
Do not normalize images two times

### DIFF
--- a/donkey.lua
+++ b/donkey.lua
@@ -69,11 +69,6 @@ local trainHook = function(self, path)
    assert(out:size(2) == oH)
    -- do hflip with probability 0.5
    if torch.uniform() > 0.5 then out = image.hflip(out) end
-   -- mean/std
-   for i=1,3 do -- channels
-      if mean then out[{{i},{},{}}]:add(-mean[i]) end
-      if std then out[{{i},{},{}}]:div(std[i]) end
-   end
    return out
 end
 
@@ -125,11 +120,6 @@ local testHook = function(self, path)
    local w1 = math.ceil((iW-oW)/2)
    local h1 = math.ceil((iH-oH)/2)
    local out = image.crop(input, w1, h1, w1+oW, h1+oW) -- center patch
-   -- mean/std
-   for i=1,3 do -- channels
-      if mean then out[{{i},{},{}}]:add(-mean[i]) end
-      if  std then out[{{i},{},{}}]:div(std[i]) end
-   end
    return out
 end
 


### PR DESCRIPTION
Currently, images are mean/std normalized two times: in `loadImage` and `trainHook` / `testHook`. Looks like copy-paste bug :)
