### PR TITLE
Clean save and load of the DataParallelTable

### DIFF
--- a/model.lua
+++ b/model.lua
@@ -36,7 +36,7 @@ print(criterion)
 if opt.retrain ~= 'none' then
    assert(paths.filep(opt.retrain), 'File not found: ' .. opt.retrain)
    print('Loading model from file: ' .. opt.retrain);
-   model = torch.load(opt.retrain)
+   model = loadDataParallel(opt.retrain, opt.nGPU) -- defined in util.lua
 end
 
 -- 4. Convert model to CUDA

--- a/train.lua
+++ b/train.lua
@@ -131,10 +131,6 @@ function train()
       for _,val in ipairs(list) do
             for name,field in pairs(val) do
                if torch.type(field) == 'cdata' then val[name] = nil end
-               if name == 'homeGradBuffers' then val[name] = nil end
-               if name == 'input_gpu' then val['input_gpu'] = {} end
-               if name == 'gradOutput_gpu' then val['gradOutput_gpu'] = {} end
-               if name == 'gradInput_gpu' then val['gradInput_gpu'] = {} end
                if (name == 'output' or name == 'gradInput') then
                   val[name] = field.new()
                end
@@ -142,7 +138,7 @@ function train()
       end
    end
    sanitize(model)
-   torch.save(paths.concat(opt.save, 'model_' .. epoch .. '.t7'), model)
+   saveDataParallel(paths.concat(opt.save, 'model_' .. epoch .. '.t7'), model) -- defined in util.lua
    torch.save(paths.concat(opt.save, 'optimState_' .. epoch .. '.t7'), optimState)
 end -- of train()
 -------------------------------------------------------------------------------------------

--- a/util.lua
+++ b/util.lua
@@ -6,11 +6,55 @@ function makeDataParallel(model, nGPU)
       assert(nGPU <= cutorch.getDeviceCount(), 'number of GPUs less than nGPU specified')
       local model_single = model
       model = nn.DataParallelTable(1)
-      for i=1, opt.nGPU do
+      for i=1, nGPU do
          cutorch.setDevice(i)
          model:add(model_single:clone():cuda(), i)
       end
       cutorch.setDevice(opt.GPU)
    end
    return model
+end
+
+local function cleanDPT(module)
+   -- This assumes this DPT was created by the function above: all the
+   -- module.modules are clones of the same network on different GPUs
+   -- hence we only need to keep one when saving the model to the disk.
+   local newDPT = nn.DataParallelTable(1)
+   cutorch.setDevice(opt.GPU)
+   newDPT:add(module:get(1), opt.GPU)
+   return newDPT
+end
+
+function saveDataParallel(filename, model)
+   if torch.type(model) == 'nn.DataParallelTable' then
+      torch.save(filename, cleanDPT(model))
+   elseif torch.type(model) == 'nn.Sequential' then
+      local temp_model = nn.Sequential()
+      for i, module in ipairs(model.modules) do
+         if torch.type(module) == 'nn.DataParallelTable' then
+            temp_model:add(cleanDPT(module))
+         else
+            temp_model:add(module)
+         end
+      end
+      torch.save(filename, temp_model)
+   else
+      error('This saving function only works with Sequential or DataParallelTable modules.')
+   end
+end
+
+function loadDataParallel(filename, nGPU)
+   local model = torch.load(filename)
+   if torch.type(model) == 'nn.DataParallelTable' then
+      return makeDataParallel(model:get(1):float(), nGPU)
+   elseif torch.type(model) == 'nn.Sequential' then
+      for i,module in ipairs(model.modules) do
+         if torch.type(module) == 'nn.DataParallelTable' then
+            model.modules[i] = makeDataParallel(module:get(1):float(), nGPU)
+         end
+      end
+      return model
+   else
+      error('The loaded model is not a Sequential or DataParallelTable module.')
+   end
 end


### PR DESCRIPTION
This PR has 3 goals that affects only users using multiple GPUs:
- Be able to recover training from a saved network. Right now when loading the DPT back, all the modules are loaded on the default GPU and the mapping from `gpuAssignments` is wrong (see [this](https://github.com/soumith/imagenet-multiGPU.torch/commit/5f8a7b28be9690de92c531316a36375bab0ecb25#commitcomment-14316613) comment by @Atcold) 
- Reduce the memory of the saved network by removing the clones of the networks
- Be able to stop the training on a machine with n GPUs and start it back on a machine with m GPUs
