### PR TITLE
Fix satellite thread Tensor indexing bug

### DIFF
--- a/dataset.lua
+++ b/dataset.lua
@@ -302,7 +302,7 @@ end
 
 -- getByClass
 function dataset:getByClass(class)
-   local index = math.ceil(torch.uniform() * self.classListSample[class]:nElement())
+   local index = math.max(1, math.ceil(torch.uniform() * self.classListSample[class]:nElement()))
    local imgpath = ffi.string(torch.data(self.imagePath[self.classListSample[class][index]]))
    return self:sampleHookTrain(imgpath)
 end


### PR DESCRIPTION
In Torch, indexing starts with `1`...
