### PR TITLE
Retrain throws error

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -44,6 +44,9 @@ function saveDataParallel(filename, model)
 end
 
 function loadDataParallel(filename, nGPU)
+   if opt.backend == 'cudnn' then
+      require 'cudnn'
+   end
    local model = torch.load(filename)
    if torch.type(model) == 'nn.DataParallelTable' then
       return makeDataParallel(model:get(1):float(), nGPU)


### PR DESCRIPTION
Use `-retrain` on a cudnn model throws error like `cannot find cudnn.SpatialSoftmax`.
Adding this will fix the problem.
