### PR TITLE
DPT Synchronize() performance fix. GPU flag fix

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -163,7 +163,10 @@ function trainBatch(inputsCPU, labelsCPU)
    optim.sgd(feval, parameters, optimState)
 
    -- DataParallelTable's syncParameters
-   model:apply(function(m) if m.syncParameters then m:syncParameters() end end)
+   if model.needsSync then
+      model:syncParameters()
+   end
+   
 
    cutorch.synchronize()
    batchNumber = batchNumber + 1

--- a/util.lua
+++ b/util.lua
@@ -10,8 +10,9 @@ function makeDataParallel(model, nGPU)
          cutorch.setDevice(i)
          model:add(model_single:clone():cuda(), i)
       end
-      cutorch.setDevice(opt.GPU)
    end
+   cutorch.setDevice(opt.GPU)
+
    return model
 end
 


### PR DESCRIPTION
Two fixes, one for performance with the latest DataParallelTable and one for the GPU flag.

`model:apply(function(m) if m.syncParameters then m:syncParameters() end end)` 
creates huge slowdowns on multi-GPU (an alexnet minibatch takes about 20 seconds on 4xTitan X, CUDNN R4), most likely due to breaking changes in the latest version of DPT.

The fix is simple:
`if model.needsSync then
      model:syncParameters()
   end`

the second issue is that the GPU flag did not work as no device was chosen if nGPU was 1. Moved the setDevice so that it is called in all cases.

Luka 
