### PR TITLE
Make vggbn.lua use `nClasses` instead of 1000.

### DIFF
--- a/models/vggbn.lua
+++ b/models/vggbn.lua
@@ -44,7 +44,7 @@ function createModel(nGPU)
    classifier:add(nn.Threshold(0, 1e-6))
    classifier:add(nn.BatchNormalization(4096, 1e-3))
    classifier:add(nn.Dropout(0.5))
-   classifier:add(nn.Linear(4096, 1000))
+   classifier:add(nn.Linear(4096, nClasses))
    classifier:add(nn.LogSoftMax())
    classifier:cuda()
 


### PR DESCRIPTION
Closes soumith/imagenet-multiGPU.torch#66
