### PR TITLE
Re-enable the cunn backend.

### DIFF
--- a/model.lua
+++ b/model.lua
@@ -29,6 +29,9 @@ else
    if opt.backend == 'cudnn' then
       require 'cudnn'
       cudnn.convert(model, cudnn)
+   elseif opt.backend == 'cunn' then
+      require 'cunn'
+      model = model:cuda()
    elseif opt.backend ~= 'nn' then
       error'Unsupported backend'
    end


### PR DESCRIPTION
Tested by running vggbn with the cunn backend and a short epochSize.

Closes soumith/imagenet-multiGPU.torch#85
